### PR TITLE
Multipart body must end with \r\n

### DIFF
--- a/lib/FormBody.php
+++ b/lib/FormBody.php
@@ -109,7 +109,7 @@ final class FormBody implements RequestBody {
             $fields[] = "\r\n";
         }
 
-        $fields[] = "--{$this->boundary}--";
+        $fields[] = "--{$this->boundary}--\r\n";
 
         return $this->cachedFields = $fields;
     }


### PR DESCRIPTION
This is RFC + otherwise aerys cuts of the last 2 bytes of the last multipart field